### PR TITLE
Backport patch for cross-compilation

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About meson-python
-==================
+About meson-python-feedstock
+============================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/meson-python-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/mesonbuild/meson-python
 
 Package license: MIT
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/meson-python-feedstock/blob/main/LICENSE.txt)
 
 Summary: Meson Python build backend (PEP 517)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,11 +7,14 @@ package:
 source:
   url: https://github.com/mesonbuild/meson-python/archive/refs/tags/{{ version }}.tar.gz
   sha256: 8e9c726aeba817c21209fc89eac38ca069e79b5238ac023f83a0be507a160804
+  patches:
+    # backport https://github.com/mesonbuild/meson-python/pull/322 for cross-compilation support
+    - patches/0001-ENH-do-not-check-extension-module-file-name-against-.patch
 
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/patches/0001-ENH-do-not-check-extension-module-file-name-against-.patch
+++ b/recipe/patches/0001-ENH-do-not-check-extension-module-file-name-against-.patch
@@ -1,0 +1,41 @@
+From dee2fbadb2f604849c05cda4fc187edd02321ebe Mon Sep 17 00:00:00 2001
+From: Daniele Nicolodi <daniele@grinta.net>
+Date: Sat, 25 Feb 2023 00:10:52 +0100
+Subject: [PATCH] ENH: do not check extension module file name against expected
+ suffix
+
+Checking that the extensions modules filenames end with a suffix
+accepted by the current Python interpreter assumes that the wheel
+being assembled is for the same Python platform. This is not true when
+cross-compiling. The check protects against a very unlikely occurrence
+and makes life harder for tools that allow cross-compiling Python
+wheels. Remove it.
+
+See #321.
+---
+ mesonpy/__init__.py | 8 ++------
+ 1 file changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/mesonpy/__init__.py b/mesonpy/__init__.py
+index 3ea1325..5f1c352 100644
+--- a/mesonpy/__init__.py
++++ b/mesonpy/__init__.py
+@@ -321,13 +321,9 @@ class _WheelBuilder():
+                 match = re.match(r'^[^.]+(.*)$', path.name)
+                 assert match is not None
+                 suffix = match.group(1)
+-                if suffix not in _EXTENSION_SUFFIXES:
+-                    raise ValueError(
+-                        f'Extension module {str(path)!r} not compatible with Python interpreter. '
+-                        f'Filename suffix {suffix!r} not in {set(_EXTENSION_SUFFIXES)}.')
+                 match = _EXTENSION_SUFFIX_REGEX.match(suffix)
+-                assert match is not None
+-                abis.append(match.group('abi'))
++                if match:
++                    abis.append(match.group('abi'))
+ 
+         stable = [x for x in abis if x and re.match(r'abi\d+', x)]
+         if len(stable) > 0 and len(stable) == len(abis) and all(x == stable[0] for x in stable[1:]):
+-- 
+2.38.1.windows.1
+


### PR DESCRIPTION
Backport https://github.com/mesonbuild/meson-python/commit/3678a77a7b6252e8fe8c984a3b2eba4b36d45417 so we can continue progressing on meson + cross-compilation, in particular in the case of scipy: https://github.com/conda-forge/scipy-feedstock/pull/205