### PR TITLE
Avoid packaging a test file with non-ascii filename

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -10,9 +10,11 @@ source:
   sha256: 9959d198aa69b57fcfd354a34518c6f795b781a73ed0656f4d01660160cc2553
 
 build:
-  number: 1
+  number: 2
   noarch: python
-  script: ${{ PYTHON }} -m pip install . -vv
+  # Avoid packaging a test package with a non-ascii filename, since that
+  # might not install depending on the target machine (see gh-29)
+  script: rm -rf tests/packages/encoding && ${{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
@@ -58,7 +60,7 @@ tests:
     script:
       - pip check
       - export CPPFLAGS=${CPPFLAGS//-DNDEBUG/}
-      - pytest tests -vv
+      - pytest tests -vv -k "not test_encoding"
 
 about:
   summary: Meson Python build backend (PEP 517)


### PR DESCRIPTION
This should prevent hard to debug install issues.

Closes gh-21
Closes gh-27
Closes gh-29

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
